### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:16.13.2-alpine3.15
 WORKDIR /elasticproxy
 
 ENV APP_NAME paatokset-elasticproxy
+ENV npm_config_cache=/app/.npm
 
 COPY package*.json ./
 RUN npm install && npm cache clean --force  


### PR DESCRIPTION
Proxy pod is failing in OpenShift with this error:

npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /.npm
npm ERR! errno -13
npm ERR!
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR!
npm ERR! To permanently fix this problem, please run:
npm ERR! sudo chown -R 1001130000:0 "/.npm"

Changing cache folder should solve the issue. This fix was added to https://github.com/City-of-Helsinki/helfi-elastic-proxy already.